### PR TITLE
Expand Measures::BundleLoader.load() to allow EP/EH selection

### DIFF
--- a/test/unit/load_mitre_bundle_test.rb
+++ b/test/unit/load_mitre_bundle_test.rb
@@ -107,4 +107,26 @@ class LoadMiteBundleTest < ActiveSupport::TestCase
     p5_ev['DENEX'].must_equal 0
   end
 
+  test "Loading a MITRE bundle from JSON via EP" do
+    dump_db
+    Measures::BundleLoader.load(@tiny_bundle, nil, nil, nil, 'ep')
+    Measure.all.count.must_equal 2
+    m0002 = Measure.where(hqmf_id: '40280381-3D61-56A7-013E-5D1EF9B76A48').first
+    m0004 = Measure.where(hqmf_id: '40280381-3D61-56A7-013E-5B2AA3493C42').first
+    assert !m0002.nil?
+    assert !m0004.nil?
+    m0002.title.must_equal "Appropriate Testing for Children with Pharyngitis"
+    m0002.populations.size.must_equal 1
+    m0002.population_criteria.keys.count.must_equal 4
+    m0004.title.must_equal "Initiation and Engagement of Alcohol and Other Drug Dependence Treatment"
+    m0004.populations.size.must_equal 6
+    m0004.population_criteria.keys.count.must_equal 7
+  end
+
+  test "Loading a MITRE bundle from JSON via EH" do
+    dump_db
+    Measures::BundleLoader.load(@tiny_bundle, nil, nil, nil, 'eh')
+    Measure.all.count.must_equal 0
+  end
+
 end


### PR DESCRIPTION
_This pull request must be merged with the bonnie pull request projecttacoma/bonnie#71 for correct application functionality._
#### Story
- https://www.pivotaltracker.com/story/show/63975288
#### Notes
- Updated <code>Measures::BundleLoader.load()</code> to take an additional, optional, input specifying whether **<code>ep</code>** or **<code>eh</code>** or both types of measures should be loaded from the specified bundle
- Added simple unit tests for verifying <code>ep</code> and <code>eh</code> measure loading
- E.g., the following commands produce the following results
  - <code>Measures::BundleLoader.load('/path/to/your/bundle-2.4.0.zip', bonnie@example.com)</code>
    - Loads all <code>measures</code>
  - <code>Measures::BundleLoader.load('/path/to/your/bundle-2.4.0.zip', bonnie@example.com,nil,nil,nil,'eh')</code>
    - Loads all **EH** <code>measures</code>
  - <code>Measures::BundleLoader.load('/path/to/your/bundle-2.4.0.zip', bonnie@example.com,nil,nil,nil,'ep')</code>
    - Loads all **EP** <code>measures</code>
  - <code>Measures::BundleLoader.load('/path/to/your/bundle-2.4.0.zip', bonnie@example.com,nil,nil,nil,'banana')</code>
    - Loads all <code>measures</code>
