### PR TITLE
change nqf_id to cms_id as a flag, and default to using hqmf_id since th...

### DIFF
--- a/lib/models/measure.rb
+++ b/lib/models/measure.rb
@@ -17,7 +17,7 @@ class Measure
   field :title, type: String
   field :description, type: String
   field :type, type: String
-  field :category, type: String
+  field :category, type: String, default: 'uncategorized'
 
   field :episode_of_care, type: Boolean
   field :continuous_variable, type: Boolean

--- a/test/unit/bundle_export_test.rb
+++ b/test/unit/bundle_export_test.rb
@@ -65,7 +65,7 @@ class BundleExportTest < ActiveSupport::TestCase
     end
     
     HealthDataStandards::CQM::Measure.each do |m|
-      assert File.exists?(File.join(@exporter.base_dir,@exporter.measures_path,m.type,"#{m.nqf_id}#{m.sub_id}.json"))
+      assert File.exists?(File.join(@exporter.base_dir,@exporter.measures_path,m.type,"#{m.hqmf_id}#{m.sub_id}.json"))
     end
 
     assert File.exists?(File.join(@exporter.base_dir,@exporter.results_path,"by_patient.json"))
@@ -127,7 +127,7 @@ class BundleExportTest < ActiveSupport::TestCase
     assert !File.exists?(@exporter.base_dir)
     @exporter.export_measures
     HealthDataStandards::CQM::Measure.each do |m|
-      assert File.exists?(File.join(@exporter.base_dir,@exporter.measures_path,m.type,"#{m.nqf_id}#{m.sub_id}.json"))
+      assert File.exists?(File.join(@exporter.base_dir,@exporter.measures_path,m.type,"#{m.hqmf_id}#{m.sub_id}.json"))
     end
   end
 


### PR DESCRIPTION
...at's always there.  Also fixed measure json export to use the measures on hand rather than trying to load them through QME.  The QME path only works when calcualte is done
