### PR TITLE
Replace usage of NQF ids with CMS ids in output statements

### DIFF
--- a/lib/measures/exporter/bundle_exporter.rb
+++ b/lib/measures/exporter/bundle_exporter.rb
@@ -173,15 +173,15 @@ module Measures
         source_path = config["hqmf_path"]
         BonnieBundler.logger.info("Exporting sources")
         measures.each do |measure|
-          html = File.read(File.expand_path(File.join(source_path, "html", "#{measure.hqmf_id}.html"))) rescue begin BonnieBundler.logger.warn("\tNo source HTML for #{measure.measure_id}"); nil end
-          hqmf1 = File.read(File.expand_path(File.join(source_path, "hqmf", "#{measure.hqmf_id}.xml"))) rescue begin BonnieBundler.logger.warn("\tNo source HQMFv1 for #{measure.measure_id}"); nil end
-          hqmf2 = HQMF2::Generator::ModelProcessor.to_hqmf(measure.as_hqmf_model) rescue BonnieBundler.logger.warn("\tError generating HQMFv2 for #{measure.measure_id}")
+          html = File.read(File.expand_path(File.join(source_path, "html", "#{measure.hqmf_id}.html"))) rescue begin BonnieBundler.logger.warn("\tNo source HTML for #{measure.cms_id || measure.measure_id}"); nil end
+          hqmf1 = File.read(File.expand_path(File.join(source_path, "hqmf", "#{measure.hqmf_id}.xml"))) rescue begin BonnieBundler.logger.warn("\tNo source HQMFv1 for #{measure.cms_id || measure.measure_id}"); nil end
+          hqmf2 = HQMF2::Generator::ModelProcessor.to_hqmf(measure.as_hqmf_model) rescue BonnieBundler.logger.warn("\tError generating HQMFv2 for #{measure.cms_id || measure.measure_id}")
           hqmf_model = JSON.pretty_generate(measure.as_hqmf_model.to_json, max_nesting: 250)
           metadata = JSON.pretty_generate(measure_metadata(measure))
 
           sources = {}
           path = File.join(sources_path, measure.type, ((config['use_cms'] ? measure.cms_id : measure.hqmf_id)))
-          export_file File.join(path, "#{measure.measure_id}.html"),html if html
+          export_file File.join(path, "#{measure.cms_id || measure.measure_id}.html"),html if html
           export_file File.join(path, "hqmf1.xml"), hqmf1 if hqmf1
           export_file File.join(path, "hqmf2.xml"), hqmf2 if hqmf2
           export_file File.join(path, "hqmf_model.json"), hqmf_model

--- a/lib/measures/loading/bundle_loader.rb
+++ b/lib/measures/loading/bundle_loader.rb
@@ -44,7 +44,7 @@ module Measures
         measure_root_entries = zip_file.glob(File.join('sources',measure_type,'*','*.json')).map {|e| File.dirname(e.name)} if measure_root_entries.empty?
         measure_root_entries.each_with_index do |measure_entry, index|
           measure = load_measure(zip_file, measure_entry, user,tmp_dir, load_from_hqmf, measure_details_hash)
-          puts "(#{index+1}/#{measure_root_entries.count}): measure #{measure.measure_id} successfully loaded from #{load_from_hqmf ? 'HQMF' : 'JSON'}"
+          puts "(#{index+1}/#{measure_root_entries.count}): measure #{measure.cms_id || measure.measure_id} successfully loaded from #{load_from_hqmf ? 'HQMF' : 'JSON'}"
         end
 
         results = extract_results(zip_file, tmp_dir)

--- a/lib/measures/loading/loader.rb
+++ b/lib/measures/loading/loader.rb
@@ -75,7 +75,7 @@ module Measures
       measure.population_criteria = json["population_criteria"]
       measure.data_criteria = json["data_criteria"]
       measure.source_data_criteria = json["source_data_criteria"]
-      puts "\tCould not find episode ids #{measure.episode_ids} in measure #{measure.measure_id}" if (measure.episode_ids && measure.episode_of_care && (measure.episode_ids - measure.source_data_criteria.keys).length > 0)
+      puts "\tCould not find episode ids #{measure.episode_ids} in measure #{measure.cms_id || measure.measure_id}" if (measure.episode_ids && measure.episode_of_care && (measure.episode_ids - measure.source_data_criteria.keys).length > 0)
       measure.measure_period = json["measure_period"]
       measure
     end

--- a/lib/measures/loading/mat_loader.rb
+++ b/lib/measures/loading/mat_loader.rb
@@ -62,7 +62,7 @@ module Measures
           end
         end
 
-        puts "measure #{measure.measure_id} successfully loaded."
+        puts "measure #{measure.cms_id || measure.measure_id} successfully loaded."
       end
       measure
     end

--- a/lib/measures/loading/sources_loader.rb
+++ b/lib/measures/loading/sources_loader.rb
@@ -11,7 +11,7 @@ module Measures
       sources_dirs.each_with_index do |measure_dir, index|
 
           measure = load_measure(measure_dir, user, vsac_user, vsac_password, measure_details_hash)
-          puts "(#{index+1}/#{sources_dirs.count}): measure #{measure.measure_id} successfully loaded."
+          puts "(#{index+1}/#{sources_dirs.count}): measure #{measure.cms_id || measure.measure_id} successfully loaded."
 
       end
 


### PR DESCRIPTION
### Story

Remnant from this [old pivotal story](https://www.pivotaltracker.com/story/show/67921654), when exporting bundles or importing mat exports, bonnie bundler's output statements utilize NQF ids rather than CMS ids. Newer versions of these measures don't always have an NQF id (`measure_id`), but will have a CMS id (`cms_id`), which is the preferred identifier.
### Notes
- replaced all usages of `measure.measure_id` with `measure.cms_id || measure.measure_id` in output logging statements
