### PR TITLE
Enable draft value sets and effective date

### DIFF
--- a/lib/measures/loading/sources_loader.rb
+++ b/lib/measures/loading/sources_loader.rb
@@ -37,7 +37,7 @@ module Measures
       measure
     end
 
-    def self.load_measure_xml(xml_path, user, vsac_user, vsac_password, measure_details, overwrite_valuesets=true, cache=false)
+    def self.load_measure_xml(xml_path, user, vsac_user, vsac_password, measure_details, overwrite_valuesets=true, cache=false, effectiveDate=nil)
       # Load the model from the document
       begin
         model = Measures::Loader.parse_hqmf_model(xml_path)
@@ -46,7 +46,7 @@ module Measures
       end
       #load the valuesets for the measure from vsac
       begin
-        value_set_models =  Measures::ValueSetLoader.load_value_sets_from_vsac( model.all_code_set_oids, vsac_user, vsac_password, user, overwrite_valuesets)
+        value_set_models =  Measures::ValueSetLoader.load_value_sets_from_vsac( model.all_code_set_oids, vsac_user, vsac_password, user, overwrite_valuesets, effectiveDate)
       rescue Exception => e
         raise VSACException.new "Error Loading Value Sets from VSAC: #{e.message}" 
       end

--- a/lib/measures/loading/value_set_loader.rb
+++ b/lib/measures/loading/value_set_loader.rb
@@ -150,7 +150,7 @@ module Measures
           if (cached_service_result && File.exists?(cached_service_result))
             vs_data = File.read cached_service_result
           else
-            vs_data = api.get_valueset(oid) 
+            vs_data = api.get_valueset(oid, nil, true) # include draft value sets
             vs_data.force_encoding("utf-8") # there are some funky unicodes coming out of the vs response that are not in ASCII as the string reports to be
             from_vsac += 1
             File.open(cached_service_result, 'w') {|f| f.write(vs_data) } unless overwrite

--- a/lib/measures/loading/value_set_loader.rb
+++ b/lib/measures/loading/value_set_loader.rb
@@ -115,7 +115,7 @@ module Measures
 
     end
 
-    def self.load_value_sets_from_vsac(value_set_oids, username, password, user=nil, overwrite=false)
+    def self.load_value_sets_from_vsac(value_set_oids, username, password, user=nil, overwrite=false, effectiveDate=nil)
       value_set_models = []
       from_vsac = 0
       
@@ -150,7 +150,7 @@ module Measures
           if (cached_service_result && File.exists?(cached_service_result))
             vs_data = File.read cached_service_result
           else
-            vs_data = api.get_valueset(oid, nil, true) # include draft value sets
+            vs_data = api.get_valueset(oid, effectiveDate, true) # include draft value sets by default
             vs_data.force_encoding("utf-8") # there are some funky unicodes coming out of the vs response that are not in ASCII as the string reports to be
             from_vsac += 1
             File.open(cached_service_result, 'w') {|f| f.write(vs_data) } unless overwrite

--- a/lib/measures/loading/value_set_loader.rb
+++ b/lib/measures/loading/value_set_loader.rb
@@ -115,7 +115,7 @@ module Measures
 
     end
 
-    def self.load_value_sets_from_vsac(value_set_oids, username, password, user=nil, overwrite=false, effectiveDate=nil)
+    def self.load_value_sets_from_vsac(value_set_oids, username, password, user=nil, overwrite=false, effectiveDate=nil, includeDraft=false)
       value_set_models = []
       from_vsac = 0
       
@@ -150,7 +150,7 @@ module Measures
           if (cached_service_result && File.exists?(cached_service_result))
             vs_data = File.read cached_service_result
           else
-            vs_data = api.get_valueset(oid, effectiveDate, true) # include draft value sets by default
+            vs_data = api.get_valueset(oid, effectiveDate, includeDraft)
             vs_data.force_encoding("utf-8") # there are some funky unicodes coming out of the vs response that are not in ASCII as the string reports to be
             from_vsac += 1
             File.open(cached_service_result, 'w') {|f| f.write(vs_data) } unless overwrite


### PR DESCRIPTION
### Stories
- https://www.pivotaltracker.com/story/show/72482370
- https://www.pivotaltracker.com/story/show/72478444
### Notes
- defaulted <code>include_draft</code> parameter to <code>true</code> for <code>api.get_valueset()</code>
- added optional parameter <code>effectiveDate</code> for specification through Bonnie's measure upload via <code>load_measure_xml()</code>
