### PR TITLE
Store complexity as associative array due to mongo key character limits

### DIFF
--- a/lib/models/measure.rb
+++ b/lib/models/measure.rb
@@ -190,13 +190,16 @@ class Measure
   # measure is saved so that the calculated complexity is cached in the DB
   before_save :calculate_complexity
   def calculate_complexity
-    self.complexity = { populations: {}, variables: {} }
+    self.complexity = { populations: [], variables: [] }
     self.population_criteria.each do |name, precondition|
-      self.complexity[:populations][name] = precondition_complexity(precondition)
+      complexity = precondition_complexity(precondition)
+      self.complexity[:populations] << { name: name, complexity: complexity }
     end
     self.source_data_criteria.each do |reference, criteria|
       next unless criteria['variable']
-      self.complexity[:variables][criteria['description']] = data_criteria_complexity(reference, calculating_variable: true)
+      name = criteria['description']
+      complexity = data_criteria_complexity(reference, calculating_variable: true)
+      self.complexity[:variables] << { name: name, complexity: complexity }
     end
     self.complexity
   end

--- a/test/unit/measure_complexity_test.rb
+++ b/test/unit/measure_complexity_test.rb
@@ -11,8 +11,8 @@ class MeasureComplexityTest < ActiveSupport::TestCase
   # Just a regression test
   test "calculate complexity" do
     Measure.count.must_equal 2
-    Measure.first.complexity[:populations].must_equal({ "DENEX"=>2, "NUMER"=>2, "DENOM"=>1, "IPP"=>8})
-    Measure.last.complexity[:populations].must_equal({ "DENEX"=>1, "NUMER"=>2, "NUMER_1"=>6, "DENOM"=>1, "IPP"=>10, "IPP_1"=>11, "IPP_2"=>10 })
+    Measure.first.complexity[:populations].must_equal([{"name"=>"DENEX", "complexity"=>2}, {"name"=>"NUMER", "complexity"=>2}, {"name"=>"DENOM", "complexity"=>1}, {"name"=>"IPP", "complexity"=>8}])
+    Measure.last.complexity[:populations].must_equal([{"name"=>"DENEX", "complexity"=>1}, {"name"=>"NUMER", "complexity"=>2}, {"name"=>"NUMER_1", "complexity"=>6}, {"name"=>"DENOM", "complexity"=>1}, {"name"=>"IPP", "complexity"=>10}, {"name"=>"IPP_1", "complexity"=>11}, {"name"=>"IPP_2", "complexity"=>10}])
   end
 
 end


### PR DESCRIPTION
Mongo doesn't allow . or $ as characters in keys, so because measure variable names can contain those characters we use an associative array instead of a hash to store complexity data.
