### PR TITLE
Removed HTML export feature from bundle_exporter

### DIFF
--- a/lib/measures/exporter/bundle_exporter.rb
+++ b/lib/measures/exporter/bundle_exporter.rb
@@ -120,8 +120,6 @@ module Measures
           patient_type = patient.type || Measure.for_patient(patient).first.try(:type)
           path = File.join(records_path, patient_type.to_s)
           export_file File.join(path, "json", "#{filename}.json"), json
-          export_file File.join(path, "html", "#{filename}.html"), html
-
         end
       end
 

--- a/test/unit/bundle_export_test.rb
+++ b/test/unit/bundle_export_test.rb
@@ -58,7 +58,6 @@ class BundleExportTest < ActiveSupport::TestCase
     
     file_name = "a_b"
     assert File.exists?(File.join(@exporter.base_dir,@exporter.records_path,record.type,"json","#{file_name}.json"))
-    assert File.exists?(File.join(@exporter.base_dir,@exporter.records_path,record.type,"html", "#{file_name}.html"))
 
     HealthDataStandards::SVS::ValueSet.each do |vs|
       assert  File.exists?(File.join(@exporter.base_dir,@exporter.valuesets_path,"json","#{vs.oid}.json"))
@@ -85,7 +84,6 @@ class BundleExportTest < ActiveSupport::TestCase
       end
     end
     assert file_names.include? File.join(@exporter.records_path, record.type, "json", "a_b.json")
-    assert file_names.include? File.join(@exporter.records_path, record.type, "html", "a_b.html")
     assert file_names.include? File.join(@exporter.results_path, "by_patient.json")
     assert file_names.include? File.join(@exporter.results_path, "by_measure.json")
   end
@@ -99,7 +97,6 @@ class BundleExportTest < ActiveSupport::TestCase
     @exporter.export_patients
     file_name = "a_b"
     assert File.exists?(File.join(@exporter.base_dir,@exporter.records_path,record.type,"json","#{file_name}.json"))
-    assert File.exists?(File.join(@exporter.base_dir,@exporter.records_path,record.type,"html", "#{file_name}.html"))
 
   end
 


### PR DESCRIPTION
Cypress no longer wants the HTML versions of patients in the exported bundle; this pull request removes the code that exports patients as HTML, leaving just the patient JSON.

Also removed assertions of HTML file existence from bundle export tests.
