### PR TITLE
Emergency and proactive fix for VSAC changing profiles.

### DIFF
--- a/lib/measures/loading/value_set_loader.rb
+++ b/lib/measures/loading/value_set_loader.rb
@@ -153,7 +153,7 @@ module Measures
             if (cached_service_result && File.exists?(cached_service_result))
               vs_data = File.read cached_service_result
             else
-              vs_data = api.get_valueset(oid, effective_date: effectiveDate, include_draft: includeDraft)
+              vs_data = api.get_valueset(oid, effective_date: effectiveDate, include_draft: includeDraft, profile: nlm_config["profile"])
               vs_data.force_encoding("utf-8") # there are some funky unicodes coming out of the vs response that are not in ASCII as the string reports to be
               from_vsac += 1
               File.open(cached_service_result, 'w') {|f| f.write(vs_data) } unless overwrite


### PR DESCRIPTION
- Added profile to the nlm part of the bonnie configuration.
  - This makes it so we can change the VSAC profile that bonnie uses without changing HDS.
- This commit makes use of the new profile config that will be added in bonnie momentarily.

Pull request will be made in bonnie after this PR is merged.
