### PR TITLE
fixed broken test. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 #gem 'health-data-standards', '3.4.4'
 
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'cql4bonnie'
-gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
+gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'master'
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'QDM_5-0'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ gemspec
 
 #gem 'health-data-standards', '3.4.4'
 
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'staging_experimental_cql'
-gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'master'
-gem 'hqmf2js', :git => 'https://github.com/pophealth/hqmf2js.git', :branch => 'master'
-gem 'hquery-patient-api', '1.0.4'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'cql4bonnie'
+gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
+gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
+gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'QDM_5-0'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 
 # gem 'health-data-standards', :path => '../health-data-standards'
@@ -37,4 +37,3 @@ group :test do
   gem 'vcr'
   gem 'webmock'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/pophealth/quality-measure-engine.git
+  revision: a0131e1981831565381224f41b77658acaf28c85
+  branch: master
+  specs:
+    quality-measure-engine (3.1.1)
+      delayed_job_mongoid (~> 2.1.0)
+      mongoid (~> 4.0.0)
+      moped (~> 2.0.0)
+      rubyzip (~> 0.9.9)
+
+GIT
   remote: https://github.com/projectcypress/health-data-standards.git
   revision: 16f9e27907adff2553c93a1882ae9251b80de5da
   branch: cql4bonnie
@@ -17,17 +28,6 @@ GIT
       rest-client (~> 1.8.0)
       rubyzip (= 0.9.9)
       uuid (~> 2.3.7)
-
-GIT
-  remote: https://github.com/projectcypress/quality-measure-engine.git
-  revision: c248d458a95041ef4ae38a182aaeff099f34adfa
-  branch: master
-  specs:
-    quality-measure-engine (3.1.2)
-      delayed_job_mongoid (~> 2.1.0)
-      mongoid (~> 4.0.0)
-      moped (~> 2.0.0)
-      rubyzip (~> 0.9.9)
 
 GIT
   remote: https://github.com/projecttacoma/hqmf2js.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,7 @@
 GIT
-  remote: https://github.com/pophealth/hqmf2js.git
-  revision: 3b1a7cb957f48cc8766f515e640af60848a834e9
-  branch: master
-  specs:
-    hqmf2js (1.3.0)
-
-GIT
-  remote: https://github.com/pophealth/quality-measure-engine.git
-  revision: a0131e1981831565381224f41b77658acaf28c85
-  branch: master
-  specs:
-    quality-measure-engine (3.1.1)
-      delayed_job_mongoid (~> 2.1.0)
-      mongoid (~> 4.0.0)
-      moped (~> 2.0.0)
-      rubyzip (~> 0.9.9)
-
-GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: ec763b50bed0f9107b5687e40073af6ef147816a
-  branch: staging_experimental_cql
+  revision: 16f9e27907adff2553c93a1882ae9251b80de5da
+  branch: cql4bonnie
   specs:
     health-data-standards (3.6.1)
       activesupport (~> 4.1.1)
@@ -35,6 +17,31 @@ GIT
       rest-client (~> 1.8.0)
       rubyzip (= 0.9.9)
       uuid (~> 2.3.7)
+
+GIT
+  remote: https://github.com/projectcypress/quality-measure-engine.git
+  revision: c248d458a95041ef4ae38a182aaeff099f34adfa
+  branch: master
+  specs:
+    quality-measure-engine (3.1.2)
+      delayed_job_mongoid (~> 2.1.0)
+      mongoid (~> 4.0.0)
+      moped (~> 2.0.0)
+      rubyzip (~> 0.9.9)
+
+GIT
+  remote: https://github.com/projecttacoma/hqmf2js.git
+  revision: 0c79fe34b54488de259dfecc33cb46294a4cd0f7
+  branch: master
+  specs:
+    hqmf2js (1.3.0)
+
+GIT
+  remote: https://github.com/projecttacoma/patientapi.git
+  revision: 5ea68b4e87d8d88385084efcb9d25ecc210fec0b
+  branch: QDM_5-0
+  specs:
+    hquery-patient-api (1.0.4)
 
 GIT
   remote: https://github.com/projecttacoma/simplexml_parser.git
@@ -98,13 +105,12 @@ GEM
       mongoid (>= 3.0, < 5)
     diffy (3.1.0)
     docile (1.1.5)
-    domain_name (0.5.20161021)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
     hashdiff (0.3.0)
     highline (1.7.8)
-    hquery-patient-api (1.0.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -201,7 +207,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     uuid (2.3.8)
       macaddr (~> 1.0)
     vcr (3.0.3)
@@ -220,7 +226,7 @@ DEPENDENCIES
   diffy
   health-data-standards!
   hqmf2js!
-  hquery-patient-api (= 1.0.4)
+  hquery-patient-api!
   minitest (~> 5.0)
   mongoid
   pry
@@ -239,4 +245,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/test/unit/bundle_export_test.rb
+++ b/test/unit/bundle_export_test.rb
@@ -52,31 +52,31 @@ class BundleExportTest < ActiveSupport::TestCase
                birthdate: 0,
                user_id: @user.id,
                gender:"M",
-               encounters: [{codes:{'SNOMED-CT':["417005"]},
+               encounters: [{codes:{'SNOMED-CT'=>["417005"]},
                              description:"Encounter, Performed: Inpatient Encounter",
                              dischargeTime:1334823300,
                              end_time:1334823300,
                              mood_code:"EVN",
                              oid:"2.16.840.1.113883.3.560.1.79",
                              start_time:1334822400,
-                             status_code:{'HL7 ActStatus':["performed"]}
+                             status_code:{'HL7 ActStatus'=>["performed"]}
                              }],
-               conditions: [{codes:{'SNOMED-CT':["433601000124106"], 'ICD-9-CM':["765.29"]},
+               conditions: [{codes:{'SNOMED-CT'=>["433601000124106"], 'ICD-9-CM'=>["765.29"]},
                              description:"Diagnosis, Active: Gestational Age >= 37 Weeks",
                              end_time:1334823300,
                              mood_code:"EVN",
                              oid:"2.16.840.1.113883.3.560.1.2",
                              start_time:1334822400,
-                             status_code:{'HL7 ActStatus':["active"], 'SNOMED-CT':["55561003"]}
+                             status_code:{'HL7 ActStatus'=>["active"], 'SNOMED-CT'=>["55561003"]}
                             },
                             {
-                             codes:{'ICD-10-CM':["Z38.00"], 'ICD-9-CM':["V30.00"]},
+                             codes:{'ICD-10-CM'=>["Z38.00"], 'ICD-9-CM'=>["V30.00"]},
                              description:"Diagnosis, Active: Single Liveborn Newborn Born In Hospital",
                              end_time:1334823300,
                              mood_code:"EVN",
                              oid:"2.16.840.1.113883.3.560.1.2",
                              start_time:1334822400,
-                             status_code:{'HL7 ActStatus':["active"], 'SNOMED-CT':["55561003"]}
+                             status_code:{'HL7 ActStatus'=>["active"], 'SNOMED-CT'=>["55561003"]}
                             }]
               }
     Record.new(patient).save

--- a/test/unit/bundle_export_test.rb
+++ b/test/unit/bundle_export_test.rb
@@ -47,7 +47,39 @@ class BundleExportTest < ActiveSupport::TestCase
     assert_equal 0,HealthDataStandards::CQM::QueryCache.count
     assert_equal 0,HealthDataStandards::CQM::PatientCache.count
     assert_equal 0,Record.count
-    Record.new({first: "a", last: "b", birthdate: 0, user_id: @user.id}).save
+    patient = {first: "a",
+               last: "b",
+               birthdate: 0,
+               user_id: @user.id,
+               gender:"M",
+               encounters: [{codes:{'SNOMED-CT':["417005"]},
+                             description:"Encounter, Performed: Inpatient Encounter",
+                             dischargeTime:1334823300,
+                             end_time:1334823300,
+                             mood_code:"EVN",
+                             oid:"2.16.840.1.113883.3.560.1.79",
+                             start_time:1334822400,
+                             status_code:{'HL7 ActStatus':["performed"]}
+                             }],
+               conditions: [{codes:{'SNOMED-CT':["433601000124106"], 'ICD-9-CM':["765.29"]},
+                             description:"Diagnosis, Active: Gestational Age >= 37 Weeks",
+                             end_time:1334823300,
+                             mood_code:"EVN",
+                             oid:"2.16.840.1.113883.3.560.1.2",
+                             start_time:1334822400,
+                             status_code:{'HL7 ActStatus':["active"], 'SNOMED-CT':["55561003"]}
+                            },
+                            {
+                             codes:{'ICD-10-CM':["Z38.00"], 'ICD-9-CM':["V30.00"]},
+                             description:"Diagnosis, Active: Single Liveborn Newborn Born In Hospital",
+                             end_time:1334823300,
+                             mood_code:"EVN",
+                             oid:"2.16.840.1.113883.3.560.1.2",
+                             start_time:1334822400,
+                             status_code:{'HL7 ActStatus':["active"], 'SNOMED-CT':["55561003"]}
+                            }]
+              }
+    Record.new(patient).save
     @exporter.rebuild_measures
     @exporter.calculate
     assert_equal 2,HealthDataStandards::CQM::QueryCache.count


### PR DESCRIPTION
issue was in change in the hqmf2js a long time ago that made the hqmf2js calculator only emit if a patient passed the IPP. previously it would always emit. Changed the patient so it would pass the IPP. Also updated the Gemfile to point to the appropriate tacoma and cypress branches on the appropriate cql branch.