### PR TITLE
Making Bonnie able to load measures exported from the MAT 5.2

### DIFF
--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -5,7 +5,7 @@ module Measures
     def self.mat_cql_export?(zip_file)
       Zip::ZipFile.open(zip_file.path) do |zip_file|
         # Check for CQL and ELM
-        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| x.name.match(/.*CQL.cql/) && !x.name.starts_with?('__MACOSX') }.first
+        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| !x.name.starts_with?('__MACOSX') }.first
         hqmf_entry = zip_file.glob(File.join('**','**.xml')).select {|x| x.name.match(/.*eMeasure.xml/) && !x.name.starts_with?('__MACOSX') }.first
         !cql_entry.nil? && !hqmf_entry.nil?
       end
@@ -54,7 +54,7 @@ module Measures
     # Opens the zip and grabs the cql file contents and hqmf_path. Returns both items.
     def self.get_files_from_zip(file, out_dir)
       Zip::ZipFile.open(file.path) do |zip_file|
-        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| x.name.match(/.*CQL.cql/) && !x.name.starts_with?('__MACOSX') }.first
+        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| !x.name.starts_with?('__MACOSX') }.first
         hqmf_entry = zip_file.glob(File.join('**','**.xml')).select {|x| x.name.match(/.*eMeasure.xml/) && !x.name.starts_with?('__MACOSX') }.first
 
         begin

--- a/lib/measures/loading/mat_loader.rb
+++ b/lib/measures/loading/mat_loader.rb
@@ -22,7 +22,7 @@ module Measures
       xls_entry = nil
       Zip::ZipFile.open(file.path) do |zip_file|
         # Check for CQL file
-        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| x.name.match(/.*CQL.cql/) && !x.name.starts_with?('__MACOSX') }.first
+        cql_entry = zip_file.glob(File.join('**','**.cql')).select {|x| !x.name.starts_with?('__MACOSX') }.first
         # Check for HQMF file
         hqmf_entry = zip_file.glob(File.join('**','**.xml')).select {|x| x.name.match(/.*eMeasure.xml/) && !x.name.starts_with?('__MACOSX') }.first
         # Check for SimpleXML file


### PR DESCRIPTION
Problem was the MAT export package renamed the CQL file to no longer be *CQL.cql, just *.cql

Copied a little logic from https://github.com/projecttacoma/bonnie_bundler/pull/77/files so that will be easier to integrate.

Will make update to Bonnie gemfile after this is merged.