### PR TITLE
cql_function_name_quote_comparison_fix

### DIFF
--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -42,7 +42,7 @@ module Measures
 
         # Replace the function name in measure observations
         model.observations.each do |obs|
-          obs[:function_name] = repl_name if obs[:function_name] == func_name
+          obs[:function_name] = repl_name if obs[:function_name] == func_name[1..-2] # Ignore quotes
         end
       end
 


### PR DESCRIPTION
Fixed issue with observation function name check to make sure quotes are ignored

Test with: [Test111_v5_2_Artifacts.zip](https://github.com/projecttacoma/bonnie_bundler/files/1081295/Test111_v5_2_Artifacts.zip)