### PR TITLE
Statement dependency structure with multi library support.

### DIFF
--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -25,10 +25,7 @@ module Measures
       # Get main measure from hqmf parser
       main_cql_library = model.cql_measure_library
 
-<<<<<<< 866fa6862a79fad1840bc826a25e674e586285ff
       # Remove spaces in functions in all libraries, including observations.
-=======
->>>>>>> Refactored removing function spacing, to be compatible with multiple libraries.
       cql_libraries, model = remove_spaces_in_functions(cql_libraries, model)
 
       # Translate the cql to elm
@@ -140,11 +137,7 @@ module Measures
           repl_name = '_' + repl_name if is_javascript_keyword(repl_name)
 
           # Avoid potential name collisions.
-<<<<<<< 866fa6862a79fad1840bc826a25e674e586285ff
           repl_name = '_' + repl_name while cql.include?(repl_name) && func_name[1..-2] != repl_name
-=======
-          repl_name = '_' + repl_name while cql.include?(repl_name) && func_name != repl_name
->>>>>>> Refactored removing function spacing, to be compatible with multiple libraries.
 
           # Store the original function name and the new name
           function_name_changes[func_name] = repl_name

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -25,7 +25,10 @@ module Measures
       # Get main measure from hqmf parser
       main_cql_library = model.cql_measure_library
 
+<<<<<<< 866fa6862a79fad1840bc826a25e674e586285ff
       # Remove spaces in functions in all libraries, including observations.
+=======
+>>>>>>> Refactored removing function spacing, to be compatible with multiple libraries.
       cql_libraries, model = remove_spaces_in_functions(cql_libraries, model)
 
       # Translate the cql to elm
@@ -137,7 +140,11 @@ module Measures
           repl_name = '_' + repl_name if is_javascript_keyword(repl_name)
 
           # Avoid potential name collisions.
+<<<<<<< 866fa6862a79fad1840bc826a25e674e586285ff
           repl_name = '_' + repl_name while cql.include?(repl_name) && func_name[1..-2] != repl_name
+=======
+          repl_name = '_' + repl_name while cql.include?(repl_name) && func_name != repl_name
+>>>>>>> Refactored removing function spacing, to be compatible with multiple libraries.
 
           # Store the original function name and the new name
           function_name_changes[func_name] = repl_name

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -30,11 +30,11 @@ module Measures
 
       # Translate the cql to elm
       elms = translate_cql_to_elm(cql_libraries)
-      
-      # Hash of which define statements are used for the measure.
+
+      # Hash of define statements to which define statements they use.
       cql_definition_dependency_structure = populate_cql_definition_dependency_structure(main_cql_library, elms, model.populations_cql_map)
-      
-      foo = traverse_new_hash(cql_definition_dependency_structure, elms)
+      # Go back for the library statements
+      cql_definition_dependency_structure = populate_used_library_dependencies(cql_definition_dependency_structure, main_cql_library, elms)
 
       # Grab the value sets from the elm
       elm_value_sets = []
@@ -188,17 +188,14 @@ module Measures
 
     # Loops over the populations and retrieves the define statements that are nested within it.
     def self.populate_cql_definition_dependency_structure(main_cql_library, elms, populations_cql_map)
-      cql_population_statement_map = {}
+      cql_statement_depencency_map = {}
       main_library_elm = elms.find { |elm| elm['library']['identifier']['id'] == main_cql_library }
-      # populations_cql_map structure is: { 'IPP' => ['Initial Population'] }
-      # Loop over the populations finding the starting statements for each.
-      populations_cql_map.each do | population, cql_population_name |
-        # Get statement that matches the cql_population_name
-        population_statement = main_library_elm['library']['statements']['def'].find { |statement| statement['name'] == cql_population_name.first }
-        # Recursive function that returns a list of statements, including duplicates
-        cql_population_statement_map[population] = retrieve_all_statements_in_population(population_statement, elms)
-      end
-      cql_population_statement_map
+
+      cql_statement_depencency_map[main_cql_library] = {}
+      main_library_elm['library']['statements']['def'].each { |statement|
+        cql_statement_depencency_map[main_cql_library][statement['name']] = retrieve_all_statements_in_population(statement, elms)
+      }
+      cql_statement_depencency_map
     end
 
     # Given a starting define statement, a starting library and all of the libraries,
@@ -213,15 +210,11 @@ module Measures
       if sub_statement_names.length > 0
         sub_statement_names.each do |sub_statement_name|
           # Check if the statement is not a built in expression 
-          sub_statement = retrieve_sub_statement_for_expression_name(sub_statement_name, elms)    
+          sub_library_name, sub_statement = retrieve_sub_statement_for_expression_name(sub_statement_name, elms)
           if sub_statement
-            all_results << sub_statement_name
-            # Call this function with the sub_statement to further drill down.
-            all_results.concat(retrieve_all_statements_in_population(sub_statement, elms))
+            all_results << { library_name: sub_library_name, statement_name: sub_statement_name }
           end
         end
-      else
-        all_results << statement['name']
       end
       all_results
     end
@@ -232,7 +225,7 @@ module Measures
     def self.retrieve_sub_statement_for_expression_name(name, elms)
       elms.each do | parsed_elm |
         parsed_elm['library']['statements']['def'].each do |statement|
-          return statement if statement['name'] == name
+          return [parsed_elm['library']['identifier']['id'], statement] if statement['name'] == name
         end
       end
       nil
@@ -259,10 +252,10 @@ module Measures
 
     # Loops over keys of the given hash and loops over the list of statements 
     # Original structure of hash is {IPP => ["In Demographics", Measurement Period Encounters"], NUMER => ["Tonsillitis"]}
-    def self.traverse_new_hash(starting_hash, elms)
+    def self.populate_used_library_dependencies(starting_hash, main_cql_library, elms)
       # Starting_hash gets updated with the create_hash_for_all call. 
-      starting_hash.keys.each do |key|
-        starting_hash[key].each do |statement|
+      starting_hash[main_cql_library].keys.each do |key|
+        starting_hash[main_cql_library][key].each do |statement|
           create_hash_for_all(starting_hash, statement, elms)
         end
       end
@@ -273,15 +266,20 @@ module Measures
     # If key is already in place, skip.
     def self.create_hash_for_all(starting_hash, key_statement, elms)
       # If key already exists, return hash
-      if starting_hash.has_key? key_statement
+      if (starting_hash.has_key?(key_statement[:library_name]) && 
+        starting_hash[key_statement[:library_name]].has_key?(key_statement[:statement_name]))
         return starting_hash
       # Create new hash key and retrieve all sub statements
       else
-        starting_hash[key_statement] = retrieve_all_statements_in_population(key_statement, elms).uniq
+        # create library hash key if needed
+        if !starting_hash.has_key?(key_statement[:library_name])
+          starting_hash[key_statement[:library_name]] = {}
+        end
+        starting_hash[key_statement[:library_name]][key_statement[:statement_name]] = retrieve_all_statements_in_population(key_statement[:statement_name], elms).uniq
         # If there are no statements return hash
-        return starting_hash if starting_hash[key_statement].empty?
+        return starting_hash if starting_hash[key_statement[:library_name]][key_statement[:statement_name]].empty?
         # Loop over array of sub statements and build out hash keys for each.
-        starting_hash[key_statement].each do |statement|
+        starting_hash[key_statement[:library_name]][key_statement[:statement_name]].each do |statement|
           starting_hash.merge!(create_hash_for_all(starting_hash, statement, elms))
         end
       end


### PR DESCRIPTION
For BONNIE-707.

fixes cql_statement_dependencies to have the single level dependency for each statement in each library. Example structure from one of the test multi library measures below.

```javascript
{
  "BonnieNesting01": {
    "Patient": [],
    "SDE Ethnicity": [],
    "SDE Payer": [],
    "SDE Race": [],
    "SDE Sex": [],
    "In Demographic": [],
    "Measurement Period Encounters": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "In Demographic"
      }
    ],
    "Pharyngitis Encounters With Antibiotics": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "Measurement Period Encounters"
      },
      {
        "library_name": "BonnieLib100",
        "statement_name": "Pharyngitis"
      },
      {
        "library_name": "BonnieLib100",
        "statement_name": "IncludesOrStartsDuring"
      },
      {
        "library_name": "BonnieLib200",
        "statement_name": "Antibiotics"
      }
    ],
    "Initial Population": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "Pharyngitis Encounters With Antibiotics"
      }
    ],
    "Denominator": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "Initial Population"
      }
    ],
    "Strep Test Encounters": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "Pharyngitis Encounters With Antibiotics"
      }
    ],
    "Numerator": [
      {
        "library_name": "BonnieNesting01",
        "statement_name": "Strep Test Encounters"
      }
    ]
  },
  "BonnieLib100": {
    "Pharyngitis": [
      {
        "library_name": "BonnieLib110",
        "statement_name": "Tonsillitis"
      }
    ],
    "IncludesOrStartsDuring": []
  },
  "BonnieLib110": {
    "Tonsillitis": []
  },
  "BonnieLib200": {
    "Antibiotics": []
  }
}
```