### PR TITLE
Turn code system OIDs into friendly code system names in the elm 

### DIFF
--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -57,6 +57,10 @@ module Measures
       # Get code systems and codes for all value sets in the elm.
       all_codes_and_code_names = HQMF2JS::Generator::CodesToJson.from_value_sets(value_set_models)
 
+      # Replace code system oids with friendly names
+      # NOTE: This is a gross patch and a better solution should be implemented
+      replace_codesystem_oids_with_names(elms)
+
       # Generate single reference code objects and a complete list of code systems and codes for the measure.
       single_code_references, all_codes_and_code_names = generate_single_code_references(elms, all_codes_and_code_names, user)
 
@@ -99,6 +103,18 @@ module Measures
       measure
     end
 
+    # Replace all the code system ids that are oids with the friendly name of the code system
+    # NOTE: This is a gross patch and a better solution should be implemented
+    def self.replace_codesystem_oids_with_names(elms)
+      elms.each do |elm|
+        elm['library']['codeSystems']['def'].each do |code_system|
+          code_name = HealthDataStandards::Util::CodeSystemHelper.code_system_for(code_system['id'])
+          # if the helper returns "Unknown" then keep what was there
+          code_system['id'] = code_name unless code_name == "Unknown"
+        end
+      end
+    end
+
     # Add single code references by finding the codes from the elm and creating new ValueSet objects
     # With a generated GUID as a fake oid.
     def self.generate_single_code_references(elms, all_codes_and_code_names, user)
@@ -110,11 +126,12 @@ module Measures
           # Loops over all single codes and saves them as fake valuesets.
           elm['library']['codes']['def'].each do |code_reference|
             code_sets = {}
-            code_system = code_reference['codeSystem']['name']
 
-            # TODO: Will it always be structured as "LOINC:2.4"?
-            code_system_name = code_system.split(":").first
-            code_system_version = code_system.split(":").last
+            # look up the referenced code system
+            code_system_def = elm['library']['codeSystems']['def'].find { |code_sys| code_sys['name'] == code_reference['codeSystem']['name'] }
+
+            code_system_name = code_system_def['id']
+            code_system_version = code_system_def['version']
 
             code_sets[code_system_name] ||= []
             code_sets[code_system_name] << code_reference['id']

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -58,7 +58,8 @@ module Measures
       all_codes_and_code_names = HQMF2JS::Generator::CodesToJson.from_value_sets(value_set_models)
 
       # Replace code system oids with friendly names
-      # NOTE: This is a gross patch and a better solution should be implemented
+      # TODO: preferred solution would be to continue using OIDs in the ELM and enable Bonnie to supply those OIDs
+      #   to the calculation engine in patient data and value sets.
       replace_codesystem_oids_with_names(elms)
 
       # Generate single reference code objects and a complete list of code systems and codes for the measure.

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -105,7 +105,8 @@ module Measures
     end
 
     # Replace all the code system ids that are oids with the friendly name of the code system
-    # NOTE: This is a gross patch and a better solution should be implemented
+    # TODO: preferred solution would be to continue using OIDs in the ELM and enable Bonnie to supply those OIDs
+    #   to the calculation engine in patient data and value sets.
     def self.replace_codesystem_oids_with_names(elms)
       elms.each do |elm|
         elm['library']['codeSystems']['def'].each do |code_system|


### PR DESCRIPTION
Also properly uses codesystem references to populate the code system for direct reference code.

This addresses the data issue of code systems not matching when comparing a direct reference code from the engine/cql with a direct reference code in a patient field. This fix is the quick patch we can make now. A proper implementation should be implemented later.

JIRA: https://jira.mitre.org/browse/BONNIE-911
JIRA Test: https://jira.mitre.org/browse/BONNIE-939

Note that the bonnie branch `cql4bonnie_BONNIE-911_prs_test` was made to point to the related PRs for this issue so the JIRA test is easier to run. There are no changes in the bonnie code.

Related PR that also needs review for this issue resolution: https://github.com/cqframework/clinical_quality_language/pull/202