### PR TITLE
merge fix error, causing draft value sets to be unloadable

### DIFF
--- a/lib/measures/loading/value_set_loader.rb
+++ b/lib/measures/loading/value_set_loader.rb
@@ -19,7 +19,7 @@ module Measures
       HealthDataStandards::SVS::ValueSet.by_user(user).in(oid: value_set_oids)
     end
 
-    def self.load_value_sets_from_vsac(value_sets, username, password, user=nil, overwrite=false, includeDraft=false, ticket_granting_ticket=nil, use_cache=false)
+    def self.load_value_sets_from_vsac(value_sets, username, password, user=nil, overwrite=false, includeDraft=false, ticket_granting_ticket=nil, use_cache=false, measure_id=nil)
       # Get a list of just the oids
       value_set_oids = value_sets.map {|value_set| value_set[:oid]}
       value_set_models = []


### PR DESCRIPTION
Fixes an error introduced in an incorrect merge (https://github.com/projecttacoma/bonnie_bundler/pull/113). To test: load a measure in bonnie (PR with Gemfile update not created yet) and leave default value sets as "Draft" as opposed to "Measure Defined".

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] JIRA ticket for this PR - N/A
- [X] JIRA ticket links to this PR - N/A
- [X] Code diff has been done and been reviewed
- [X] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced - N/A
- [X] Tests are included and test edge cases -- see above 
- [X] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [X] Automated regression test(s) pass - N/A

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA test links - N/A
- [X] Justification for using no regression tests: we want this merge error fixed ASAP
- [X] JIRA tests have been added to sprint - N/A


**Reviewer 1:** @edeyoung 

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:** @mayerm94 

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
