### PR TITLE
updated gemfile.lock for HDS 4.0.1 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.6)
-    health-data-standards (4.0.0)
+    health-data-standards (4.0.1)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)


### PR DESCRIPTION
Updated gemfile.lock for HDS 4.0.1. bonnie-bundler gem release is not needed right now.

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)

**Reviewer 1:**

Name: @losborne 
- [x] Does the reference change look right?
- [x] Do the tests work?

**Reviewer 2:**

Name: @jbradl11 
- [x] Does the reference change look right?
- [x] Do the tests work?