### PR TITLE
Refactored injecting GUIDs as the code list ids for data criteria int…

### DIFF
--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -256,7 +256,7 @@ module Measures
             single_code_references << { guid: code_guid, code_system_name: code_system_name, code: code_reference['id'] }
             all_codes_and_code_names[code_guid] = code_sets
             # Code_guids are unique hashes, there's no sense in adding duplicates to the ValueSet collection
-            if !HealthDataStandards::SVS::ValueSet.all().where(oid: code_guid).first()
+            if !HealthDataStandards::SVS::ValueSet.all().where(oid: code_guid, user_id: user.id).first()
               # Create a new "ValueSet" and "Concept" object and save.
               valueSet = HealthDataStandards::SVS::ValueSet.new({oid: code_guid, display_name: code_reference['name'], version: '' ,concepts: [], user_id: user.id})
               concept = HealthDataStandards::SVS::Concept.new({code: code_reference['id'], code_system_name: code_system_name, code_system_version: code_system_version, display_name: code_reference['name']})

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -62,7 +62,6 @@ module Measures
       # Loop over data criteria to search for data criteria that is using a single reference code.
       # Once found set the Data Criteria's 'code_list_id' to our fake oid. Do the same for source data criteria.
       json['data_criteria'].each do |data_criteria_name, data_criteria|
-        # We do not want to replace an existing code_list_id. Skip it, unless it is a GUID.
         unless data_criteria['code_list_id']
           if data_criteria['inline_code_list']
             # Check to see if inline_code_list contains the correct code_system and code for a direct reference code.

--- a/lib/measures/loading/cql_loader.rb
+++ b/lib/measures/loading/cql_loader.rb
@@ -251,17 +251,18 @@ module Measures
 
             code_sets[code_system_name] ||= []
             code_sets[code_system_name] << code_reference['id']
-            # Generate a unique number as our fake "oid"
-            code_guid = SecureRandom.uuid
-            # Keep a list of generated_guids and a hash of guids with code system names and codes.
+            # Generate a unique number as our fake "oid" based on parameters that identify the DRC
+            code_guid = "drc-" + Digest::SHA2.hexdigest("#{code_system_name} #{code_reference['id']} #{code_reference['name']}")            # Keep a list of generated_guids and a hash of guids with code system names and codes.
             single_code_references << { guid: code_guid, code_system_name: code_system_name, code: code_reference['id'] }
-
             all_codes_and_code_names[code_guid] = code_sets
-            # Create a new "ValueSet" and "Concept" object and save.
-            valueSet = HealthDataStandards::SVS::ValueSet.new({oid: code_guid, display_name: code_reference['name'], version: '' ,concepts: [], user_id: user.id})
-            concept = HealthDataStandards::SVS::Concept.new({code: code_reference['id'], code_system_name: code_system_name, code_system_version: code_system_version, display_name: code_reference['name']})
-            valueSet.concepts << concept
-            valueSet.save!
+            # Code_guids are unique hashes, there's no sense in adding duplicates to the ValueSet collection
+            if !HealthDataStandards::SVS::ValueSet.all().where(oid: code_guid).first()
+              # Create a new "ValueSet" and "Concept" object and save.
+              valueSet = HealthDataStandards::SVS::ValueSet.new({oid: code_guid, display_name: code_reference['name'], version: '' ,concepts: [], user_id: user.id})
+              concept = HealthDataStandards::SVS::Concept.new({code: code_reference['id'], code_system_name: code_system_name, code_system_version: code_system_version, display_name: code_reference['name']})
+              valueSet.concepts << concept
+              valueSet.save!
+            end
           end
         end
       end

--- a/test/unit/cql_loader_test.rb
+++ b/test/unit/cql_loader_test.rb
@@ -24,4 +24,30 @@ class CQLLoaderTest < ActiveSupport::TestCase
       assert_equal [], cql_statement_dependencies['Hospice']['Has Hospice']
     end
   end
+
+
+  test 'Loading a measure with a direct reference code handles the creation of code_list_id hash properly' do
+    direct_reference_mat_export = File.new File.join('test', 'fixtures', 'CMS158_v5_4_Artifacts_Update.zip')
+    VCR.use_cassette('valid_vsac_response_158_update') do
+      dump_db
+      user = User.new
+      user.save
+
+      measure_details = { 'episode_of_care'=> false }
+      Measures::CqlLoader.load(direct_reference_mat_export, user, measure_details, ENV['VSAC_USERNAME'], ENV['VSAC_PASSWORD']).save
+      assert_equal 1, CqlMeasure.all.count
+      measure = CqlMeasure.all.first
+      # Confirm that the source data criteria with the direct reference code starts with 'drc-'
+      assert measure['source_data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D_source']['code_list_id'].starts_with?('drc-')
+      assert measure['data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D']['code_list_id'].starts_with?('drc-')
+
+      # Re-load the Measure
+      Measures::CqlLoader.load(direct_reference_mat_export, user, measure_details, ENV['VSAC_USERNAME'], ENV['VSAC_PASSWORD']).save
+      assert_equal 2, CqlMeasure.all.count
+      measures = CqlMeasure.all
+      # Confirm that the Direct Reference Code, code_list_id hash has not changed between Uploads.
+      assert_equal measures[0]['source_data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D_source']['code_list_id'], measures[1]['source_data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D_source']['code_list_id']
+      assert_equal measures[0]['data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D']['code_list_id'], measures[1]['data_criteria']['prefix_5195_3_LaboratoryTestPerformed_70C9F083_14BD_4331_99D7_201F8589059D']['code_list_id']
+    end
+  end
 end


### PR DESCRIPTION
…o a separate function

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

Refactored code that adds code_list_ids to the Measure's source data criteria and data criteria into a separate function. This will allow us to easily call this function in our "rebuild_elm" script in Bonnie.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR:  https://jira.mitre.org/browse/BONNIE-1242
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases. 
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
    * In rare situations, this may not be possible or applicable to a PR. In those situations:
        1. Note why this could not be done or is not applicable here:
        2. Add TODOs in the code noting that it requires a test
        3. Add a JIRA task to add the test and link it here:
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree

  
  