### PR TITLE
Updated bonnie_bundler for 2.1.0 release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
+# gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
 # gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
 # gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 # gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,9 @@
-GIT
-  remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 8afa4ba276a47f08ad46a941c167a5115b1627f1
-  branch: master_bonnie
-  specs:
-    health-data-standards (4.0.3)
-      activesupport (~> 4.2.0)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-      highline (~> 1.7.0)
-      log4r (~> 1.1.10)
-      memoist (~> 0.9.1)
-      mongoid (~> 5.0.0)
-      mongoid-tree (~> 2.0.0)
-      nokogiri (~> 1.8.2)
-      protected_attributes (~> 1.0.5)
-      rest-client (~> 1.8.0)
-      rubyzip (~> 1.2.1)
-      uuid (~> 2.3.7)
-      zip-zip (~> 0.3)
-
 PATH
   remote: .
   specs:
-    bonnie_bundler (2.0.3)
+    bonnie_bundler (2.1.0)
       diffy (~> 3.0.0)
+      health-data-standards (~> 4.0)
       hqmf2js (~> 1.4)
       hquery-patient-api (~> 1.1)
       mongoid (~> 5.0)
@@ -104,6 +84,21 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.6)
+    health-data-standards (4.0.4)
+      activesupport (~> 4.2.0)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      highline (~> 1.7.0)
+      log4r (~> 1.1.10)
+      memoist (~> 0.9.1)
+      mongoid (~> 5.0.0)
+      mongoid-tree (~> 2.0.0)
+      nokogiri (~> 1.8.2)
+      protected_attributes (~> 1.0.5)
+      rest-client (~> 1.8.0)
+      rubyzip (~> 1.2.1)
+      uuid (~> 2.3.7)
+      zip-zip (~> 0.3)
     highline (1.7.8)
     hike (1.2.3)
     hqmf2js (1.4.0)
@@ -260,7 +255,6 @@ DEPENDENCIES
   awesome_print
   bonnie_bundler!
   bundler-audit
-  health-data-standards!
   minitest (~> 5.0)
   pry
   pry-nav

--- a/bonnie-bundler.gemspec
+++ b/bonnie-bundler.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
   s.email = "pophealth-talk@googlegroups.com"
   s.homepage = "http://github.com/projecttacoma/bonnie_bundler"
   s.authors = ["The MITRE Corporation"]
-  s.version = '2.0.3'
+  s.version = '2.1.0'
   s.license = 'Apache-2.0'
 
-  # s.add_dependency 'health-data-standards', '~> 4.0'
+  s.add_dependency 'health-data-standards', '~> 4.0'
   s.add_dependency 'quality-measure-engine', '~> 3.2'
   s.add_dependency 'hquery-patient-api', '~> 1.1'
   s.add_dependency 'simplexml_parser', '~> 1.0'


### PR DESCRIPTION
Updated to version 2.1.0. To follow semantic version we are going to 2.1.0 instead of 2.0.4 due to breaking changes with the interfacing with bonnie.

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1451
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
