### PR TITLE
added VSAC api support to fetch the latest profile for a program

### DIFF
--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -172,7 +172,12 @@ module Util
       end
 
       ##
-      # Gets the latest profile for a program
+      # Gets the latest profile for a program. This is a separate call from the program details call. It returns JSON
+      # with only the name of the latest profile and the timestamp of the request. ex:
+      #   {
+      #     "name": "eCQM Update 2018-05-04",
+      #     "requestTime": "2018-05-21 03:39:04 PM"
+      #   }
       #
       # Optional parameter program is the program to request from the API. If it is not provided it will look for
       # a :program in the config passed in during construction. If there is no :program in the config it will use 

--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -172,6 +172,38 @@ module Util
       end
 
       ##
+      # Gets the latest profile for a program
+      #
+      # Optional parameter program is the program to request from the API. If it is not provided it will look for
+      # a :program in the config passed in during construction. If there is no :program in the config it will use 
+      # the DEFAULT_PROGRAM constant for the program.
+      #
+      # Returns the name of the latest profile for the given program.
+      def get_latest_profile_for_program(program = nil)
+        # if no program was provided use the one in the config or default in constant
+        if program.nil?
+          program = @config.fetch(:program, DEFAULT_PROGRAM)
+        end
+
+        begin
+          # parse json response and return it
+          parsedResponse = JSON.parse(RestClient.get("#{@config[:utility_url]}/program/#{ERB::Util.url_encode(program)}/latest%20profile"))
+
+          # As of 5/17/18 VSAC does not return 404 when an invalid profile is provided. It just doesnt fill the name
+          # attribute in the 200 response. We need to check this.
+          if !parsedResponse['name'].nil?
+            return parsedResponse['name']
+          else
+            raise VSACProgramNotFoundError.new(program)
+          end
+
+        # keeping this rescue block in case the API is changed to return 404 for invalid profile
+        rescue RestClient::ResourceNotFound
+          raise VSACProgramNotFoundError.new(program)
+        end
+      end
+
+      ##
       # Gets the releases for a program. This may be used without credentials.
       #
       # Optional parameter program is the program to request from the API. If it is not provided it will look for

--- a/test/fixtures/vcr_cassettes/vsac_util_get_latest_profile_for_program_CMS_eCQM.yml
+++ b/test/fixtures/vcr_cassettes/vsac_util_get_latest_profile_for_program_CMS_eCQM.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://vsac.nlm.nih.gov/vsac/program/CMS%20eCQM/latest%20profile
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '72'
+      Date:
+      - Thu, 17 May 2018 13:39:30 GMT
+      Set-Cookie:
+      - BIGipServervsacweb_p=!gjgpljECCT0SWr7NtNHn4GsLooFbUxOwIRTnyLmMPPLqsyPnSfkFr/NITt4Yh4Jaw1OR1Rih8Ghnp6c=;
+        expires=Thu, 17-May-2018 15:39:30 GMT; path=/; Httponly; Secure
+      X-Vip-Info:
+      - 130.14.16.40:443
+      X-Pool-Info:
+      - "/Common/vsacweb_p 10.1.5.114 8080"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"name":"eCQM Update 2018-05-04","requestTime":"2018-05-17 09:39:30
+        AM"}'
+    http_version: 
+  recorded_at: Thu, 17 May 2018 13:39:30 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/vsac_util_get_latest_profile_for_program_invalid.yml
+++ b/test/fixtures/vcr_cassettes/vsac_util_get_latest_profile_for_program_invalid.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://vsac.nlm.nih.gov/vsac/program/Fake%20Program/latest%20profile
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '40'
+      Date:
+      - Thu, 17 May 2018 13:39:30 GMT
+      Set-Cookie:
+      - BIGipServervsacweb_p=!CLsEMgdFnW3bRfDm9OGvBt4MxRMcjrEVY8cdRpHtXPSP+3AnVzmCsTSM6YIPSG2dw+05YFSqHcRtXkk=;
+        expires=Thu, 17-May-2018 15:39:30 GMT; path=/; Httponly; Secure
+      X-Vip-Info:
+      - 130.14.16.40:443
+      X-Pool-Info:
+      - "/Common/vsacweb_p 10.1.5.114 8080"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"requestTime":"2018-05-17 09:39:30 AM"}'
+    http_version: 
+  recorded_at: Thu, 17 May 2018 13:39:30 GMT
+recorded_with: VCR 3.0.3

--- a/test/unit/vsac_api_util_test.rb
+++ b/test/unit/vsac_api_util_test.rb
@@ -136,4 +136,26 @@ class VSACAPIUtilTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'get_latest_profile_for_program for valid program' do
+    VCR.use_cassette("vsac_util_get_latest_profile_for_program_CMS_eCQM") do
+      latest_profile = @api.get_latest_profile_for_program('CMS eCQM')
+      assert_equal "eCQM Update 2018-05-04", latest_profile
+    end
+  end
+
+  test 'get_latest_profile_for_program for default program' do
+    VCR.use_cassette("vsac_util_get_latest_profile_for_program_CMS_eCQM") do
+      latest_profile = @api.get_latest_profile_for_program
+      assert_equal "eCQM Update 2018-05-04", latest_profile
+    end
+  end
+
+  test 'get_latest_profile_for_program for invalid program' do
+    VCR.use_cassette("vsac_util_get_latest_profile_for_program_invalid") do
+      assert_raise Util::VSAC::VSACProgramNotFoundError do
+        @api.get_latest_profile_for_program('Fake Program')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds support to fetch the latest profile for a given program.

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1502 https://jira.mitre.org/browse/BONNIE-1507
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
    * In rare situations, this may not be possible or applicable to a PR. In those situations:
        1. Note why this could not be done or is not applicable here: There a single line of code for catching a 404 response from the server for invalid profile. This doesn't happen right now and I couldn't easily make a test for that situation, but it is included incase VSAC fixes that in the future.
        2. Add TODOs in the code noting that it requires a test
        3. Add a JIRA task to add the test and link it here:

| branch | coverage |
| - | - |
| master | 804 / 1261 LOC (63.76%) |
| vsac_latest_profile_bonnie-1502 | 813 / 1271 LOC (63.97%) |

- [x] Automated regression test(s) pass N/A no calculation code changed

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: @c-monkey
- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A
