### PR TITLE
Nokogiri update bonnie prior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_pars
 # gem 'health-data-standards', :path => '../health-data-standards'
 # gem 'quality-measure-engine', :path => '../quality-measure-engine'
 # gem 'hqmf2js', :path => '../hqmf2js'
-# #gem 'hquery-patient-api', :path => '../patientapi'
+# gem 'hquery-patient-api', :path => '../patientapi'
 # gem 'simplexml_parser', :path => '../simplexml_parser'
 
 gem 'rails', '~> 4.2.7'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'nokogiri_update_bonnie_prior'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'mongoid5'
 gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'bump_mongoid'
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'nokogiri_update_bonnie_prior'
 gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'bonnie-prior'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'mongoid5'
 gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'bump_mongoid'
-gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'nokogiri_update_bonnie_prior'
+gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'bonnie-prior'
 gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'bonnie-prior'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'bonnie-prior'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,9 @@
 source "https://rubygems.org"
 gemspec
 
-#gem 'health-data-standards', '3.4.4'
-
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'mongoid5'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'nokogiri_update_bonnie_prior'
 gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'bump_mongoid'
-gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'bonnie-prior'
+gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'nokogiri_update_bonnie_prior'
 gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'bonnie-prior'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'bonnie-prior'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: e00c0010bf9ee5fe3a11df1ee6c04780971711bd
-  branch: nokogiri_update_bonnie_prior
+  revision: 525e2e494939fe13893386310d906713470a1bd3
+  branch: mongoid5
   specs:
     health-data-standards (3.7.0)
       activesupport (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: f3d437762d6ba9736b11c26ce1e467ff75c49190
-  branch: mongoid5
+  revision: e00c0010bf9ee5fe3a11df1ee6c04780971711bd
+  branch: nokogiri_update_bonnie_prior
   specs:
     health-data-standards (3.7.0)
       activesupport (~> 4.2.0)
@@ -10,9 +10,10 @@ GIT
       highline (~> 1.7.0)
       log4r (~> 1.1.10)
       memoist (~> 0.9.1)
+      mongo (~> 2.4.3)
       mongoid (~> 5.0.0)
       mongoid-tree (~> 2.0.0)
-      nokogiri (~> 1.8.2)
+      nokogiri (~> 1.8.3)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
       rubyzip (~> 1.2.1)
@@ -32,11 +33,10 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/hqmf2js.git
-  revision: 5c7aa718f313edcc17a7d35a5b1badf99610b10b
-  branch: bonnie-prior
+  revision: d5bfea9d638c3790f89ee101d36d6aae1f321002
+  branch: nokogiri_update_bonnie_prior
   specs:
     hqmf2js (1.3.0)
-      health-data-standards (~> 3.7)
       hquery-patient-api (~> 1.0.4)
       rails (~> 4.2.7)
 
@@ -98,7 +98,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.4)
     awesome_print (1.2.0)
-    bson (4.2.1)
+    bson (4.3.0)
     builder (3.2.3)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
@@ -118,7 +118,7 @@ GEM
       mongoid-compatibility
     diffy (3.0.7)
     docile (1.1.3)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.1.0)
@@ -127,7 +127,8 @@ GEM
     highline (1.7.10)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.4)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     libv8 (3.16.14.19)
     log4r (1.1.10)
     loofah (2.2.2)
@@ -141,8 +142,8 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_portile2 (2.3.0)
-    minitest (5.10.2)
-    mongo (2.4.2)
+    minitest (5.11.3)
+    mongo (2.4.3)
       bson (>= 4.2.1, < 5.0.0)
     mongoid (5.0.2)
       activemodel (~> 4.0)
@@ -156,7 +157,7 @@ GEM
       mongoid (>= 4.0, < 6.0)
     multi_json (1.11.2)
     netrc (0.11.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     origin (2.3.1)
     protected_attributes (1.0.9)
@@ -228,12 +229,12 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.1)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    uuid (2.3.8)
+    uuid (2.3.9)
       macaddr (~> 1.0)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)
@@ -267,4 +268,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,11 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/hqmf2js.git
-  revision: d5bfea9d638c3790f89ee101d36d6aae1f321002
-  branch: nokogiri_update_bonnie_prior
+  revision: 56392bbe59e4e51f140c90271dd76797c122198c
+  branch: bonnie-prior
   specs:
     hqmf2js (1.3.0)
+      health-data-standards (~> 3.7)
       hquery-patient-api (~> 1.0.4)
       rails (~> 4.2.7)
 

--- a/bonnie-bundler.gemspec
+++ b/bonnie-bundler.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   # s.add_dependency 'quality-measure-engine', '~>3'
   
   s.files = s.files = `git ls-files`.split("\n")
-  # s.add_dependency 'health-data-standards', '~> 3.4.4'
 end
 
 

--- a/bonnie-bundler.gemspec
+++ b/bonnie-bundler.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   # s.add_dependency 'quality-measure-engine', '~>3'
   
   s.files = s.files = `git ls-files`.split("\n")
+  # s.add_dependency 'health-data-standards', '~> 3.4.4'
 end
 
 


### PR DESCRIPTION
Update nokogiri due to security vulnerability

move old gem reference to gemspec (commented out because we are pointing at branch now)
- [x] ❗️ change Gemfile to point to `bonnie-prior` branch for hqmf2js once https://github.com/projecttacoma/hqmf2js/pull/56 is merged.
- [x] ❗️ change Gemfile to point to `mongoid5` branch for health-data-standards once https://github.com/projectcypress/health-data-standards/pull/591 is merged.

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1620
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. NA
- [x] Automated regression test(s) pass (N/A bonnie-prior)

**Reviewer 1:**

Name: @hossenlopp 
- [x] Gem version update sanity check

