### PR TITLE
update rubyzip for zipslip vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       rubyzip
       spreadsheet (> 0.6.4)
     ruby-ole (1.2.11.7)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 525e2e494939fe13893386310d906713470a1bd3
+  revision: 4f802877b8c69b19f616f47fb5f1d74dbfb7bdbc
   branch: mongoid5
   specs:
     health-data-standards (3.7.0)


### PR DESCRIPTION
Update version because of https://github.com/snyk/zip-slip-vulnerability

- [x] Update Gemfile.lock

Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1738
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases NA
- [x] You have tried to break the code

**Reviewer 2:**

Name:
~- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose~
~- [ ] The tests appropriately test the new code, including edge cases~
~- [ ] You have tried to break the code~