### PR TITLE
Updated bonnie_bundler for 2.2.5 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 PATH
   remote: .
   specs:
-    bonnie_bundler (2.2.4)
+    bonnie_bundler (2.2.5)
       diffy (~> 3.0.0)
       health-data-standards (~> 4.3.2)
       hqmf2js (~> 1.4)

--- a/bonnie-bundler.gemspec
+++ b/bonnie-bundler.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email = "pophealth-talk@googlegroups.com"
   s.homepage = "http://github.com/projecttacoma/bonnie_bundler"
   s.authors = ["The MITRE Corporation"]
-  s.version = '2.2.4'
+  s.version = '2.2.5'
   s.license = 'Apache-2.0'
 
   s.add_dependency 'health-data-standards', '~> 4.3.2'


### PR DESCRIPTION
Pull requests into Bonnie Bundler require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

- [x] Gem version updated appropriately